### PR TITLE
 Ensure project packages are installed as the project user (TEQ-78)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,17 @@ Tequila-nodejs
 
 Changes
 
+v 0.8.2 on Nov 21, 2018
+-----------------------
+
+* Updated project dependencies to ensure that project packages
+  get installed as the project user. Prior to this release,
+  geerlingguy.nodejs would install both Node and the project
+  Node dependencies as root, causing permissions issues.
+  Now Node and project Node dependencies are installed in
+  two separate steps, the former as root, the latter as
+  the project user.
+
 v 0.8.1 on Jul 23, 2018
 -----------------------
 

--- a/README.rst
+++ b/README.rst
@@ -63,17 +63,17 @@ project requires ::
     ---
     # file: deployment/requirements.yml
     - src: https://github.com/caktus/tequila-common
-      version: v0.8.0
+      version: v0.8.8
 
     - src: https://github.com/caktus/tequila-django
-      version: v0.9.11
+      version: v0.9.18
 
     - src: geerlingguy.nodejs
-      version: 4.1.2
+      version: 4.2.2
       name: nodejs
 
     - src: https://github.com/caktus/tequila-nodejs
-      version: v0.8.1
+      version: v0.8.2
 
 Run ``ansible-galaxy`` with your requirements file ::
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Django project deployment -- nodejs
   company: Caktus Consulting Group, LLC
   license: BSD
-  min_ansible_version: 1.9
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions: all

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,4 +14,11 @@ galaxy_info:
     - installer
     - web
 dependencies:
-  - { role: geerlingguy.nodejs }
+  # First, install nodejs as root, but don't install any packages
+  - role: geerlingguy.nodejs
+    become: true
+    nodejs_package_json_path: ""
+  # Second, install packages as the project user to ensure node_modules are
+  # installed as the project user:
+  - role: geerlingguy.nodejs
+    become_user: "{{ project_user }}"


### PR DESCRIPTION
This change addresses errors we have seen on selectgeorgia (and other projects) where the gearlingguy.nodejs package will install dependencies as root (occasionally failing for that reason). This change:
 * Installs node as root.
 * Installs packages as the project owner.
 * Updates the documentation to use the latest versions of roles.

See also https://github.com/caktus/selectgeorgia/pull/373 for an example of a project that would use this change.