### PR TITLE
add support for django-webpack-loader

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ source_dir: "{{ root_dir }}/src"
 project_user: "{{ project_name }}"
 ignore_devdependencies: false
 npm_run_command: build
+uses_webpack_loader: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,3 +23,8 @@
   become_user: "{{ project_user }}"
   vars:
     ansible_ssh_pipelining: true
+
+- name: cp webpack-stats.json webpack-stats-live.json
+  command: cp webpack-stats.json webpack-stats-live.json
+  become_user: "{{ project_user }}"
+  when: uses_webpack_loader

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,5 +26,7 @@
 
 - name: cp webpack-stats.json webpack-stats-live.json
   command: cp webpack-stats.json webpack-stats-live.json
+  args:
+    chdir: "{{ source_dir }}"
   become_user: "{{ project_user }}"
   when: uses_webpack_loader


### PR DESCRIPTION
Add a play that executes if `uses_webpack_loader` is `true`.

When requests are made to the server after a deploy, `django-webpack-loader` causes a 500 WebpackLoaderBadStatsError when `webpack-stats.json` is read. Changing the name of the stats file invalidates the webpack-loader's cache, hopefully preventing this error.